### PR TITLE
Use correct paths

### DIFF
--- a/FindSDL2_gfx.cmake
+++ b/FindSDL2_gfx.cmake
@@ -42,14 +42,14 @@ if (NOT SDL2_GFX_LIBRARIES)
     find_library(SDL2_GFX_LIBRARY_RELEASE
         NAMES SDL2_gfx
         PATH_SUFFIXES lib ${_SDL2_GFX_PATH_SUFFIX}
-        PATHS ${SDL2_PATH}
+        PATHS ${SDL2_GFX_PATH}
     )
 
     # Look for the debug version of SDL2.
     find_library(SDL2_GFX_LIBRARY_DEBUG
         NAMES SDL2_gfxd
         PATH_SUFFIXES lib ${_SDL2_GFX_PATH_SUFFIX}
-        PATHS ${SDL2_PATH}
+        PATHS ${SDL2_GFX_PATH}
     )
 
     include(SelectLibraryConfigurations)

--- a/FindSDL2_image.cmake
+++ b/FindSDL2_image.cmake
@@ -42,14 +42,14 @@ if (NOT SDL2_IMAGE_LIBRARIES)
     find_library(SDL2_IMAGE_LIBRARY_RELEASE
         NAMES SDL2_image
         PATH_SUFFIXES lib ${_SDL2_IMAGE_PATH_SUFFIX}
-        PATHS ${SDL2_PATH}
+        PATHS ${SDL2_IMAGE_PATH}
     )
 
     # Look for the debug version of SDL2.
     find_library(SDL2_IMAGE_LIBRARY_DEBUG
         NAMES SDL2_imaged
         PATH_SUFFIXES lib ${_SDL2_IMAGE_PATH_SUFFIX}
-        PATHS ${SDL2_PATH}
+        PATHS ${SDL2_IMAGE_PATH}
     )
 
     include(SelectLibraryConfigurations)

--- a/FindSDL2_mixer.cmake
+++ b/FindSDL2_mixer.cmake
@@ -42,14 +42,14 @@ if (NOT SDL2_MIXER_LIBRARIES)
     find_library(SDL2_MIXER_LIBRARY_RELEASE
         NAMES SDL2_mixer
         PATH_SUFFIXES lib ${_SDL2_MIXER_PATH_SUFFIX}
-        PATHS ${SDL2_PATH}
+        PATHS ${SDL2_MIXER_PATH}
     )
 
     # Look for the debug version of SDL2.
     find_library(SDL2_MIXER_LIBRARY_DEBUG
         NAMES SDL2_mixerd
         PATH_SUFFIXES lib ${_SDL2_MIXER_PATH_SUFFIX}
-        PATHS ${SDL2_PATH}
+        PATHS ${SDL2_MIXER_PATH}
     )
 
     include(SelectLibraryConfigurations)

--- a/FindSDL2_net.cmake
+++ b/FindSDL2_net.cmake
@@ -42,14 +42,14 @@ if (NOT SDL2_NET_LIBRARIES)
     find_library(SDL2_NET_LIBRARY_RELEASE
         NAMES SDL2_net
         PATH_SUFFIXES lib ${_SDL2_NET_PATH_SUFFIX}
-        PATHS ${SDL2_PATH}
+        PATHS ${SDL2_NET_PATH}
     )
 
     # Look for the debug version of SDL2.
     find_library(SDL2_NET_LIBRARY_DEBUG
         NAMES SDL2_netd
         PATH_SUFFIXES lib ${_SDL2_NET_PATH_SUFFIX}
-        PATHS ${SDL2_PATH}
+        PATHS ${SDL2_NET_PATH}
     )
 
     include(SelectLibraryConfigurations)

--- a/FindSDL2_ttf.cmake
+++ b/FindSDL2_ttf.cmake
@@ -42,14 +42,14 @@ if (NOT SDL2_TTF_LIBRARIES)
     find_library(SDL2_TTF_LIBRARY_RELEASE
         NAMES SDL2_ttf
         PATH_SUFFIXES lib ${_SDL2_TTF_PATH_SUFFIX}
-        PATHS ${SDL2_PATH}
+        PATHS ${SDL2_TTF_PATH}
     )
 
     # Look for the debug version of SDL2.
     find_library(SDL2_TTF_LIBRARY_DEBUG
         NAMES SDL2_ttfd
         PATH_SUFFIXES lib ${_SDL2_TTF_PATH_SUFFIX}
-        PATHS ${SDL2_PATH}
+        PATHS ${SDL2_TTF_PATH}
     )
 
     include(SelectLibraryConfigurations)


### PR DESCRIPTION
Use SDL2_<PACKAGE_NAME>_PATH for finding libraries. Otherwise i get error (in this case for SDL_ttf):

```
[cmake] CMake Error at C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/Common7/IDE/CommonExtensions/Microsoft/CMake/CMake/share/cmake-3.17/Modules/FindPackageHandleStandardArgs.cmake:164 (message):
[cmake]   Could NOT find SDL2_ttf (missing: SDL2_TTF_LIBRARIES) (found version "2.0.15")
```