### PR TITLE
Fix the "The package name passed to `find_package_handle_standard_args` does not match the name of the calling package" warning

### DIFF
--- a/FindSDL2.cmake
+++ b/FindSDL2.cmake
@@ -82,7 +82,8 @@ find_package_handle_standard_args(SDL2
 
 find_package_handle_standard_args(SDL2main
     REQUIRED_VARS SDL2main_LIBRARIES SDL2_INCLUDE_DIR
-    VERSION_VAR SDL2_VERSION_STRING)
+    VERSION_VAR SDL2_VERSION_STRING
+    NAME_MISMATCHED)
 
 if(SDL2_FOUND)
     set(SDL2_LIBRARIES ${SDL2_LIBRARY})


### PR DESCRIPTION
Hi @opeik modern versions of CMake issue the following warning with your modules:

```
CMake Warning (dev) at /usr/share/cmake-3.25/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (SDL2main)
  does not match the name of the calling package (SDL2).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/FindSDL2.cmake:83 (find_package_handle_standard_args)
  CMakeLists.txt:58 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This PR is intended to convince CMake that this mismatch is intentional.